### PR TITLE
Hacky removal of double json - I do not know go...

### DIFF
--- a/message.go
+++ b/message.go
@@ -182,10 +182,10 @@ func to(message []string,
 }
 
 func writeMessage(ws *websocket.Conn, message []string) {
-	b, err := json.Marshal(strings.Join(message, "|"))
-	if err == nil && ws != nil {
-		log.Printf("INFO - Writing %s to %\n", string(b), ws)
-		ws.WriteMessage(websocket.TextMessage, b)
+	b := strings.Join(message, "|")
+	if ws != nil {
+		log.Printf("INFO - Writing %s to %\n", b, ws)
+		ws.WriteMessage(websocket.TextMessage, []byte(b))
 	}
 }
 

--- a/signalbox.go
+++ b/signalbox.go
@@ -91,12 +91,9 @@ func messagePump(config Configuration, msg chan Message, ws *websocket.Conn) {
 		ws.SetReadDeadline(time.Now().Add(config.SocketTimeout * time.Second))
 
 		// Pump the new message into the signalbox.
-		var message string
-		json.Unmarshal([]byte(socketContents), &message)
+		log.Printf("Recieved %s from %p", socketContents, ws)
 
-		log.Printf("Recieved %s from %p", message, ws)
-
-		msg <- Message{ws, message}
+		msg <- Message{ws, socketContents}
 	}
 }
 


### PR DESCRIPTION
I'm not suggesting merging this as I really know zero go, but I removed the double JSON encoding / decoding and it now works with later rtc-signaller / rtc-quickconnect versions.  Let me know if you'd like a hand converting stuff to the new versions...
